### PR TITLE
bsdcpio: provided by bsdtar

### DIFF
--- a/hrmpf.packages
+++ b/hrmpf.packages
@@ -277,7 +277,6 @@ syslinux
 vboot-utils
 
 # archives
-bsdcpio
 bsdtar
 bzip2
 cabextract


### PR DESCRIPTION
```
openvpn
polipo
privoxy
rsyslog
stunnel
tftp-hpa
unbound
xinetd
ledger
sc
when ...
Unable to locate 'bsdcpio' in repository pool.
ERROR: Missing required binary packages, exiting...
$ xlocate bsdcpio
bsdtar-3.2.0_5	/usr/bin/bsdcpio
bsdtar-3.2.0_5	/usr/share/man/man1/bsdcpio.1
```