### PR TITLE
remove support for <udev-176

### DIFF
--- a/dracut/59-mtd.rules
+++ b/dracut/59-mtd.rules
@@ -3,6 +3,6 @@ ACTION!="add|change", GOTO="ps_end"
 # Also don't process disks that are slated to be a multipath device
 ENV{DM_MULTIPATH_DEVICE_PATH}=="?*", GOTO="ps_end"
 
-KERNEL=="mtdblock[0-9]*", IMPORT BLKID
+KERNEL=="mtdblock[0-9]*", IMPORT{builtin}="blkid"
 
 LABEL="ps_end"

--- a/dracut/61-mtd.rules
+++ b/dracut/61-mtd.rules
@@ -10,7 +10,7 @@ GOTO="pss_end"
 
 LABEL="do_pss"
 # by-path (parent device path)
-ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="", DEVPATH!="*/virtual/*", IMPORT PATH_ID
+ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="", DEVPATH!="*/virtual/*", IMPORT{builtin}="path_id"
 ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}"
 ENV{DEVTYPE}=="partition", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}-part%n"
 

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -19,7 +19,6 @@ install() {
         inst /usr/bin/memdiskfind
         instmods mtdblock phram
         inst_rules "$moddir/59-mtd.rules" "$moddir/61-mtd.rules"
-        prepare_udev_rules 59-mtd.rules 61-mtd.rules
         inst_hook pre-udev 01 "$moddir/mtd.sh"
     fi
 


### PR DESCRIPTION
See https://github.com/dracutdevs/dracut/pull/2104 for upstream changes in dracut.

As of today, this PR is just a simplification, but with future releases of dracut, without this PR hrmpf might no longer work. 