### PR TITLE
mklive.sh: clean up kernels on aarch64 as well

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -268,7 +268,7 @@ generate_initramfs() {
 
     # unnecessary inside the image
     rm "$ROOTFS"/boot/initramfs*
-    rm "$ROOTFS"/boot/vmlinuz*
+    rm "$ROOTFS"/boot/vmlinu{z,x}*
 }
 
 cleanup_rootfs() {


### PR DESCRIPTION
When building on aarch64, I saw this scroll by - 

```
dracut[I]: *** Creating initramfs image file '/boot/initrd' done ***
rm: cannot remove '/home/zdykstra/source/hrmpf/mklive-build.Gy8NZ/image/rootfs/boot/vmlinuz*': No such file or directory
[8/11] Generating GRUB support for EFI systems...
```

